### PR TITLE
Cambiando el label tamaño matriz

### DIFF
--- a/main.py
+++ b/main.py
@@ -738,7 +738,7 @@ frmC = Frame(frmP, bg='#d1f497')
 frmP.pack(padx=10, pady=10)
 frmC.pack(padx=10, pady=10)
 
-lblTamanioMatriz = Label(frmC, text="Seleccione el tamaño de la matriz (entre 8 y 16):", bg='#d1f497',
+lblTamanioMatriz = Label(frmC, text="Seleccione el tamaño de la matriz (mínimo 7):", bg='#d1f497',
                          font=("Arial", 12))
 lblTipoMatriz = Label(frmC, text="¿Cómo desea generar la matriz?", bg='#d1f497', font=("Arial", 12))
 


### PR DESCRIPTION
This pull request includes a small change to the `main.py` file. The change updates the label text for selecting the matrix size in the `confirmarPeso` function.

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L741-R741): Changed the label text from "Seleccione el tamaño de la matriz (entre 8 y 16)" to "Seleccione el tamaño de la matriz (mínimo 7)" in the `confirmarPeso` function.